### PR TITLE
Fix stdout/stderr types

### DIFF
--- a/purepy_remctl.py
+++ b/purepy_remctl.py
@@ -84,8 +84,8 @@ def remctl(host, port=4373, principal=None, command=None):
     if command is None:
         raise TypeError("The command argument must be provided.")
 
-    stdout = ''
-    stderr = ''
+    stdout = b''
+    stderr = b''
     status = None
     try:
         r = Remctl(host, port, principal)


### PR DESCRIPTION
stdout/stderr are created as strs, which is incompatible with the later attempts to append bytes to those vars